### PR TITLE
Add logging structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ __pycache__
 # graphviz flowchart files
 *.gv
 *.pdf
+
+# logfiles
+*.log

--- a/rtdp/python/rtdp.py
+++ b/rtdp/python/rtdp.py
@@ -32,7 +32,7 @@ def get_parser():
         version=f'%(prog)s {RTDP_CLI_APP_VERSION_STR}')
     parser.add_argument('--log_file', type=str,
                         default=RTDP_CLI_DEFAULT_LOGFILE, help='log file name')
-    parser.add_argument('--log_level', type=str, default='info',
+    parser.add_argument('--log_level', type=str, default='debug',
                         choices=['debug', 'info', 'warning', 'error', 'critical'],
                         help='log level: debug, info, warning, error, critical')
     parser.add_argument('config_file', nargs='?',

--- a/rtdp/python/rtdp.py
+++ b/rtdp/python/rtdp.py
@@ -4,9 +4,9 @@
 Entry point of rdtp.
 """
 
-import argparse
 # Logging cookboook: https://docs.python.org/3/howto/logging-cookbook.html
-# import logging
+import logging
+import argparse
 
 from rtdp_config_parser import ERSAPReader
 from rtdp_dash_cyto import get_dash_app
@@ -15,6 +15,7 @@ RTDP_CLI_APP_DESCRIP_STR = \
     "rtdp: JLab's streaming readout RealTime Development and testing Platform."
 RTDP_CLI_APP_URL_STR = "https://github.com/JeffersonLab/SRO-RTDP"
 RTDP_CLI_APP_VERSION_STR = "0.0"
+RTDP_CLI_DEFAULT_LOGFILE = "rtdp.log"
 
 def get_parser():
     """Define the application arguments. Create the ArgumentParser object and return it.
@@ -29,9 +30,26 @@ def get_parser():
     )
     parser.add_argument('-v', '--version', action='version',
         version=f'%(prog)s {RTDP_CLI_APP_VERSION_STR}')
+    parser.add_argument('--log_file', type=str,
+                        default=RTDP_CLI_DEFAULT_LOGFILE, help='log file name')
+    parser.add_argument('--log_level', type=str, default='info',
+                        choices=['debug', 'info', 'warning', 'error', 'critical'],
+                        help='log level: debug, info, warning, error, critical')
     parser.add_argument('config_file', nargs='?',
         help='path to your YAML configuration file')
     return parser
+
+
+def setup_logging(log_file, log_level):
+    """Setup the logging instance."""
+    numeric_level = getattr(logging, log_level.upper(), None)
+    if not isinstance(numeric_level, int):
+        raise ValueError(f'Invalid log level: {log_level}')
+
+    logging.basicConfig(filename=log_file, level=numeric_level,
+                        format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+    logging.info("Start application rtdp")
+
 
 
 def run_rtdp(parser):
@@ -41,9 +59,11 @@ def run_rtdp(parser):
     - parser (argparse.ArgumentParser): The created argument parser.
     """
     args = parser.parse_args()
+
+    setup_logging(args.log_file, args.log_level)
+
     if args.config_file:
         # TODO: using ERSAP reader here. Should be generalized.
-        # TODO: not a service launching yet.
         configurations = ERSAPReader(args.config_file)
         ersap_nodes = configurations.get_flowchart_nodes()
 

--- a/rtdp/python/rtdp_config_parser.py
+++ b/rtdp/python/rtdp_config_parser.py
@@ -6,9 +6,13 @@ Read the configurations from yaml file and visualize it as DAG.
 
 from abc import ABC, abstractmethod
 import sys
+import logging
 import json
 import yaml
 from graphviz import Digraph
+
+
+logger = logging.getLogger(__name__)
 
 
 class ConfigReader(ABC):
@@ -16,7 +20,7 @@ class ConfigReader(ABC):
 
     def __init__(self, filepath):
         self.config_data = self._get_config(filepath)
-        print(f"\nStarting the platform using the specified YAML configuration file: {filepath}")
+        logger.info("Parsed the yaml configuration file at %s", filepath)
         # self._pprint_config()
 
     def _get_config(self, filepath):
@@ -28,7 +32,7 @@ class ConfigReader(ABC):
         Returns:
         - config_data : A dictionary containing the configuration data.
         """
-        with open(filepath, 'r') as file:
+        with open(filepath, 'r', encoding="utf-8") as file:
             try:
                 config_data = yaml.safe_load(file)
                 return config_data
@@ -48,7 +52,7 @@ class ConfigReader(ABC):
     def graphviz_flowchart(self):
         """Visualize the configuration file that the name of each service
         is treated as a node in a DAG."""
-        # TODO: this function is not called  by the main now.
+        # This function is not called  by the main now.
         node_list = self.get_flowchart_nodes()
 
         # graphviz examples: https://graphviz.readthedocs.io/en/stable/examples.html
@@ -67,6 +71,8 @@ class ConfigReader(ABC):
 
 
 class ERSAPFlowchartNode:
+    """Definition of an ERSAP node."""
+
     def __init__(self, item):
         """Definition of an ERSAP flowchart node. Currently it's only for visulization.
         It may support services launching in the future (needs to figure out parameter
@@ -90,6 +96,7 @@ class ERSAPFlowchartNode:
 
 
 class ERSAPReader(ConfigReader):
+    """Rules to load and parse ERSAP yaml configuration file."""
 
     def _validate_ioservices(self):
         """Validate the config yaml file has "io-services" and its sub "reader" and "writer."""
@@ -127,6 +134,7 @@ class ERSAPReader(ConfigReader):
         return node_list
 
     def print_nodes(self):
+        """Print all the ERSAP service nodes."""
         node_list = self.get_flowchart_nodes()
 
         print("\n\nThe ERSAP services:\n")

--- a/rtdp/python/rtdp_dash_cyto.py
+++ b/rtdp/python/rtdp_dash_cyto.py
@@ -4,11 +4,13 @@
 Layouts and callbacks of the Dash application using dash_cytoscape library.
 """
 
+import logging
 # Dash modules. Ref: https://dash.plotly.com
 from dash import html, Dash, Input, Output, callback
 # Dash cytoscape. Ref: https://dash.plotly.com/cytoscape
 import dash_cytoscape as cyto
 
+logger = logging.getLogger(__name__)
 
 # dash_cytoscape stylesheets
 cyto_display_stylesheet_config_flowchart=[
@@ -65,7 +67,7 @@ def get_cytoscape_elements(node_list):
             'data': {'source': str(i), 'target': str(i + 1)},
             'selectable': False
             })
-
+    logger.info("Cytoscape elements created")
     return r
 
 
@@ -98,22 +100,24 @@ def get_dash_app(nodes):
                 stylesheet=cyto_display_stylesheet_config_flowchart
             )
         ]),
-        # Ref: https://dash.plotly.com/cytoscape/events
+
+        # Display the info about the selected ERSAP flowchart node using the callback function.
         html.Div([
             html.Pre(id='cyto-tapNode-resp', style=styles['pre'])
         ])
     ])
 
-
+    # Ref: https://dash.plotly.com/cytoscape/events
     @callback(Output('cyto-tapNode-resp', 'children'),
               Input('cyto-display-config-flowchart', 'tapNodeData'))
     def display_tap_config_node(data):
         if not data:
             return html.H4("No service selected.")
 
+        logger.debug("On config flowchart, node-%s selected", data['id'])
         node_id = int(data['id'])
         node_info = nodes[node_id]
-        # TODO: better CSS style
+
         return html.Div([
             html.H4(f"Selected service: {data['label']}"),
             html.P(f"  class: {node_info.cls}\n  language: {node_info.lan}\n")


### PR DESCRIPTION
Address issue #23. Updated the argparser and the submodules.
```
age: rtdp [-h] [-v] [--log_file LOG_FILE] [--log_level {debug,info,warning,error,critical}] [config_file]

rtdp: JLab's streaming readout RealTime Development and testing Platform.

positional arguments:
  config_file           path to your YAML configuration file

options:
  -h, --help            show this help message and exit
  -v, --version         show program's version number and exit
  --log_file LOG_FILE   log file name
  --log_level {debug,info,warning,error,critical}
                        log level: debug, info, warning, error, critical

Github page: https://github.com/JeffersonLab/SRO-RTDP
```
Updates:
- [x] Add to arguments `log_file` and `log_level` to argparse.
- [x] If not specified, the application would log to `rtdp.log`. Logs of previous runs would not be overwritten.
- [x] Log level is configurable. By default it's "debug".

Part of the logging file:
```
2023-12-18 16:30:00,605 - root - INFO - Start application rtdp
2023-12-18 16:30:00,615 - rtdp_config_parser - INFO - Parsed the yaml configuration file at ../java/config_demo_ersap.yml
2023-12-18 16:30:00,620 - rtdp_dash_cyto - INFO - Cytoscape elements created
2023-12-18 16:30:08,883 - rtdp_dash_cyto - DEBUG - On config flowchart, node-0 selected
2023-12-18 16:30:12,961 - rtdp_dash_cyto - DEBUG - On config flowchart, node-8 selected
``` 