### PR TITLE
Set podiostream host and port via config. parameter.

### DIFF
--- a/src/utilities/cpp/podiostream/podiostreamSource.cc
+++ b/src/utilities/cpp/podiostream/podiostreamSource.cc
@@ -72,10 +72,11 @@ podiostreamSource::podiostreamSource(std::string resource_name, JApplication* ap
 
     LOG << "Creating podiostreamSource for \"" << resource_name << "\"" << LOG_END;
 
+    app->SetDefaultParameter("podiostream:host", m_host, "Host name of podio TCP stream source to connect to an pull events from");
+    app->SetDefaultParameter("podiostream:port", m_port, "Port number of podio TCP stream source to connect to an pull events from");
+
     // Setup network communication via zmq
-    std::string host = "ifarm180302";
-    std::string port = "5557";
-    std::string url  = "tcp://" + host + ":" + port;
+    std::string url  = "tcp://" + m_host + ":" + m_port;
     worker.set(zmq::sockopt::rcvhwm, 1); // Set High Water Mark for maximum number of messages to queue before stalling
     worker.connect(url);
     LOG << "<--> PODIO stream will connect to: " << url << LOG_END;

--- a/src/utilities/cpp/podiostream/podiostreamSource.h
+++ b/src/utilities/cpp/podiostream/podiostreamSource.h
@@ -59,7 +59,9 @@ protected:
 
     zmq::context_t context;
     zmq::socket_t worker;
-    // Long64_t m_event_in_tree = 0;
+
+    std::string m_host = "localhost";
+    std::string m_port = "5557";
 
     MyTMessage *m_myTM = nullptr;
     TMemFile *m_memfile = nullptr;


### PR DESCRIPTION
Add ability to set podiostream source host and port via JANA config.parameters.