### PR TITLE
Fix pcapSplit

### DIFF
--- a/src/utilities/cpp/evio2csv/evio2csv.cc
+++ b/src/utilities/cpp/evio2csv/evio2csv.cc
@@ -1,3 +1,6 @@
+//
+// g++ evio2csv.cc -o evio2csv
+//
 
 #include <iostream>
 #include <fstream>
@@ -108,8 +111,9 @@ void swap( uint32_t *buff, size_t Nwords){
 //---------------------------------------
 int main(int narg, char* argv[]){
 
+	if( narg<2 ){ std::cout << "Usage:  evio2csv file.evio" << std::endl;}
 	
-	std::string fname = "port7001.evio";
+	std::string fname = argv[1];
 	std::ifstream ifs(fname.c_str(), std::ifstream::binary);
 	if(! ifs.is_open() ){
 		std:cerr << "Unable to open file: " << fname << std::endl;

--- a/src/utilities/cpp/pcap2evio/pcap2evio.cc
+++ b/src/utilities/cpp/pcap2evio/pcap2evio.cc
@@ -1,3 +1,4 @@
+
 //
 //  g++ pcap2evio.cc -o pcap2evio -lpcap
 //
@@ -44,8 +45,9 @@ void packet_handler(u_char *user_data, const struct pcap_pkthdr *pkthdr, const u
 			uint64_t Nbytes_to_write = payload_length;
 			
 			// The first 14 bytes have an unknown format so we drop them.
-			if( Nbytes_written<14 ){
-				uint64_t Nskip = 14 - Nbytes_written; // bytes left to skip
+            const uint64_t bytes_to_skip = 14;
+			if( Nbytes_written<bytes_to_skip ){
+				uint64_t Nskip = bytes_to_skip - Nbytes_written; // bytes left to skip
 				if( Nskip > Nbytes_to_write) Nskip = Nbytes_to_write;
 				payload += Nskip;
 				Nbytes_to_write -= Nskip;
@@ -93,6 +95,7 @@ int main(int argc, char *argv[]) {
         std::cerr << "pcap_open_offline() failed: " << errbuf << "\n";
         return 2;
     }
+    std::cout << "Opened file: " << infile << "  (snaplen=" << pcap_snapshot(handle) << ")" << std::endl;
 
 	// Open output file
     std::ofstream ofile(outfile.c_str(), std::ios::out | std::ios::binary);

--- a/src/utilities/cpp/pcapSplit/pcapSplit.cc
+++ b/src/utilities/cpp/pcapSplit/pcapSplit.cc
@@ -6,7 +6,7 @@
 // encountered in the file.
 //
 //
-// g++ -g -std=c++20 -o pcapSplit pcapSplit.cc -lpcap
+// g++ -g -std=c++2a -o pcapSplit pcapSplit.cc -lpcap
 //
 //
 // This was mostly written by Grimoire on ChatGPT
@@ -23,13 +23,47 @@
 #include <sys/stat.h>
 #include <chrono>
 
+uint32_t g_snaplen = 65535; // this will get overridden with snaplen of input pcap file
+
 void write_packet_to_file(std::unordered_map<uint16_t, std::ofstream>& port_files, const std::string& base_filename, const struct pcap_pkthdr* header, const u_char* packet, uint16_t port);
 
+// Define the on-disk packet header struct with 32-bit values
+struct pcap_pkthdr_disk {
+    uint32_t ts_sec;   // time stamp seconds
+    uint32_t ts_usec;  // time stamp microseconds
+    uint32_t caplen;   // length of portion present
+    uint32_t len;      // length this packet (off wire)
+};
+
+//-------------------------------
+// show_progress
+//-------------------------------
 void show_progress(size_t current, size_t total) {
     float progress = (float)current / total * 100;
     std::cout << "\rProgress: " << progress << "%        " << std::flush;
 }
 
+//-------------------------------
+// write_pcap_file_header
+//
+// Function to write pcap file header to a new file
+//-------------------------------
+void write_pcap_file_header(std::ofstream& file) {
+    pcap_file_header file_header;
+    file_header.magic = 0xa1b2c3d4;
+    file_header.version_major = PCAP_VERSION_MAJOR;
+    file_header.version_minor = PCAP_VERSION_MINOR;
+    file_header.thiszone = 0;
+    file_header.sigfigs = 0;
+    file_header.snaplen = g_snaplen;
+    file_header.linktype = DLT_EN10MB;
+
+    file.write(reinterpret_cast<const char*>(&file_header), sizeof(file_header));
+}
+
+//-------------------------------
+// process_pcap
+//-------------------------------
 void process_pcap(const std::string& filename) {
     char errbuf[PCAP_ERRBUF_SIZE];
     pcap_t* handle = pcap_open_offline(filename.c_str(), errbuf);
@@ -48,6 +82,9 @@ void process_pcap(const std::string& filename) {
     size_t total_size = st.st_size;
     size_t processed_size = 0;
 
+    // Retrieve snaplen from the input pcap file header
+    g_snaplen = pcap_snapshot(handle);
+
     struct pcap_pkthdr* header;
     const u_char* packet;
     int res;
@@ -61,10 +98,12 @@ void process_pcap(const std::string& filename) {
 
     auto last_update = std::chrono::steady_clock::now();
 
+    uint32_t max_caplen = 0;
     while ((res = pcap_next_ex(handle, &header, &packet)) >= 0) {
         if (res == 0) continue;
 
         processed_size += header->caplen;
+        if( header->caplen > max_caplen ) max_caplen = header->caplen;
 
         struct ethhdr* eth = (struct ethhdr*) packet;
         if (ntohs(eth->h_proto) == ETH_P_IP) {
@@ -98,8 +137,13 @@ void process_pcap(const std::string& filename) {
     // Ensure final progress is 100%
     show_progress(total_size, total_size);
     std::cout << std::endl;
+
+    std::cout << "Max caplen: " << max_caplen << std::endl;
 }
 
+//-------------------------------
+// write_packet_to_file
+//-------------------------------
 void write_packet_to_file(std::unordered_map<uint16_t, std::ofstream>& port_files, const std::string& directory, const struct pcap_pkthdr* header, const u_char* packet, uint16_t port) {
     if (port_files.find(port) == port_files.end()) {
         std::string file_path = directory + "/" + "port" + std::to_string(port) + ".pcap";
@@ -108,14 +152,27 @@ void write_packet_to_file(std::unordered_map<uint16_t, std::ofstream>& port_file
             std::cerr << "Could not open file: " << file_path << std::endl;
             return;
         }
-        std::cout << "opened file: " << file_path << " for writing" << std::endl;
+        std::cout << "opened file: " << file_path << " for writing  (snaplen=" << g_snaplen << ")" << std::endl;
+
+        // Write the pcap file header to the new file
+        write_pcap_file_header(port_files[port]);
     }
 
+    // Convert pcap_pkthdr to pcap_pkthdr_disk for on-disk format
+    pcap_pkthdr_disk disk_header;
+    disk_header.ts_sec = header->ts.tv_sec;
+    disk_header.ts_usec = header->ts.tv_usec;
+    disk_header.caplen = header->caplen;
+    disk_header.len = header->len;
+
     std::ofstream& file = port_files[port];
-    file.write(reinterpret_cast<const char*>(header), sizeof(struct pcap_pkthdr));
+    file.write(reinterpret_cast<const char*>(&disk_header), sizeof(disk_header));
     file.write(reinterpret_cast<const char*>(packet), header->caplen);
 }
 
+//-------------------------------
+// main
+//-------------------------------
 int main(int argc, char* argv[]) {
     if (argc != 2) {
         std::cerr << "Usage: " << argv[0] << " <pcap_file>" << std::endl;


### PR DESCRIPTION
This fixes the pcapSplit program so it produces valid pcap files.

It adds the ability to specify the input file from the command line for evio2csv.

It also adds minor tweaks to pcap2evio.