### PR TITLE
GPU proxy updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@ __pycache__
 build
 *.build
 
+# insatll files
+bin
+
 # IDE files
 .idea
 SRO-RTDP.iml

--- a/rtdp/cuda/gpu_proxy/CMakeLists.txt
+++ b/rtdp/cuda/gpu_proxy/CMakeLists.txt
@@ -41,3 +41,7 @@ set_target_properties(gpu_emu PROPERTIES CUDA_SEPARABLE_COMPILATION ON)
 
 # Link necessary libraries (CUDA, ZeroMQ, SQLite)
 target_link_libraries(gpu_emu CUDA::cudart CUDA::cublas CUDA::curand ${ZMQ_LIBRARY} ${SQLite3_LIBRARIES})
+
+# Install 
+install(TARGETS gpu_emu DESTINATION bin)
+install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/python_zmq_helper/" DESTINATION bin FILES_MATCHING PATTERN "*.py")

--- a/rtdp/cuda/gpu_proxy/README.md
+++ b/rtdp/cuda/gpu_proxy/README.md
@@ -38,7 +38,7 @@ Luckily we have the `ZMQ` (`so` only) and `sqlite` dependency on the native OS, 
    /home/xmei/projects/SRO-RTDP/rtdp/cuda/gpu_proxy/  # change dir as needed
    bash-5.1$ rm -rf build  # clean the existing build
    bash-5.1$ mkdir build && cd build
-   bash-5.1$ cmake ..
+   bash-5.1$ cmake -DCMAKE_INSTALL_PREFIX=.. ..  # set install path
    ...
    -- The CUDA compiler identification is NVIDIA 12.8.61
    ...
@@ -47,6 +47,7 @@ Luckily we have the `ZMQ` (`so` only) and `sqlite` dependency on the native OS, 
    bash-5.1$ make -j64
    ...
    [100%] Built target gpu_emu
+   bash-5.1$ make install  # install without sudo
    ```
 
 

--- a/rtdp/cuda/gpu_proxy/gpuEmu.cu
+++ b/rtdp/cuda/gpu_proxy/gpuEmu.cu
@@ -363,7 +363,6 @@ int main(int narg, char *argv[]){
         CUDA_CALL(cudaFree(d_in));
         CUDA_CALL(cudaFree(d_rand));
         CUDA_CALL(cudaFree(d_out));
-
     }
 
     return 0;

--- a/rtdp/cuda/gpu_proxy/gpuEmu.cu
+++ b/rtdp/cuda/gpu_proxy/gpuEmu.cu
@@ -120,8 +120,7 @@ public:
 
     std::string out_ip = "127.0.0.1";  // Default out IP is local
     bool useTensorCores = false;
-    bool test = false;
-    bool debug = false;
+    bool verbose = false;
 
     std::string sqliteFilename;      // SQL file parameter
 
@@ -154,10 +153,8 @@ public:
                 }
             } else if (arg == "--tc") {
                 options.useTensorCores = true;
-            } else if (arg == "-t" || arg == "--test") {
-                options.test = true;
-            } else if (arg == "-d" || arg == "--debug") {
-                options.debug = true;
+            } else if (arg == "-v" || arg == "--verbose") {
+                options.verbose = true;
             }
         }
         return options;
@@ -166,7 +163,7 @@ public:
 
     static void PrintUsage() {
         std::cout << "\n" 
-                  << "Usage: gpu_emu [--in-port port] [-a|--out-ip] [--out-port port]\n"
+                  << "Usage: gpu_emu [--in-port] [-a|--out-ip] [--out-port]\n"
                   << "\n"
                   << "-h, --help     Print this help statement\n"
                   << "    --in-port  <port> Set ZMQ port to listen on (default is 55555)\n"
@@ -174,10 +171,9 @@ public:
                   << "    --out-port <port> Set ZMQ port to push to (default is 55556)\n"
                   << "-r, --rate     Control the ratio of output/input volume (default is 0.5)\n"
                   << "-w, --width    Set the GPU input matrix column size (default is 2048)\n"
-                  << "-s, --sqlfile  <file> Specify the SQL rate logger file\n"
+                //   << "-s, --sqlfile  <file> Specify the SQL rate logger file\n"
                 //   << "    --tc       Use GPU Tensor Cores instead of FP units\n"
-                  << "-t, --test     Verify the GPU computation results\n"
-                  << "-d, --debug    Enable the debug mode\n"
+                  << "-v, --verbose    Enable the verbose mode (default is false)\n"
 
                   << "\n"
                   << "This is a GPU Proxy\n"
@@ -185,7 +181,7 @@ public:
                   << "multiplication on the GPU. After that, it copies the result back to CPU and PUSH to\n"
                   << "another ZMQ IP & port.\n"
                   << "\n"
-                  << "If --sqlfile is used, it specifies a SQLite rate logger.\n"
+                //   << "If --sqlfile is used, it specifies a SQLite rate logger.\n"
                   << "\n";
     }
 };
@@ -198,7 +194,7 @@ void monitorTraffic(size_t* inBytes, size_t* outBytes) {
     using namespace std::chrono;
     while (true) {
         size_t prevIn = *inBytes, prevOut = *outBytes;
-        std::this_thread::sleep_for(seconds(1));
+        std::this_thread::sleep_for(seconds(2));
         size_t curIn = *inBytes, curOut = *outBytes;
         std::cout << "Incoming: " << ((curIn - prevIn) * 8.0 / 1e6) << " Mbps, "
                   << "Outgoing: " << ((curOut - prevOut) * 8.0 / 1e6) << " Mbps" << std::endl;
@@ -214,8 +210,8 @@ int main(int narg, char *argv[]){
     // Parse command options (will print help and exit if help is asked for)
     CommandLineOptions options = CommandLineOptions::Parse(narg, argv);
 
-    // Enable debug mode if the --debug flag is provided
-    bool debug_mode = options.debug;
+    // Enable the verbose mode if the cmd flag is provided
+    bool verbose_mode = options.verbose;
 
     //............................................
     // Setup network communication via zmq
@@ -249,21 +245,6 @@ int main(int narg, char *argv[]){
     }
     //............................................
 
-    //............................................
-    // Monitoring thread
-    // size_t inBytes = 0, outBytes = 0;
-    // std::thread monitor(monitorTraffic, &inBytes, &outBytes);
-    // monitor.detach();
-    //............................................
-
-    //............................................
-    // SQL logger setup
-    // if (!options.sqliteFilename.empty() && !rate_logger.openDB(options.sqliteFilename)) {
-    //     std::cerr << "Failed to open database: " << options.sqliteFilename << std::endl;
-    //     return 1;
-    // }
-    //............................................
-
 
     std::cout << "\nWaiting for data ...\n" << std::endl;
 
@@ -274,13 +255,17 @@ int main(int narg, char *argv[]){
         auto res = receiver.recv(recv_buffer, zmq::recv_flags::none);
         if (!res) {
             std::cerr << "Error: ZeroMQ receive failed!" << std::endl;
-        } else {
+        }
+
+        if (verbose_mode) {
             std::cout << "Received [" << res.value() << "] bytes from ZeroMQ socket." << std::endl;
         }
         
         size_t curr_inBytes = recv_buffer.size();
         if( curr_inBytes == 0 ) { 
-            std::cout << "  (skipping empty buffer)" << std::endl;
+            if (verbose_mode) {
+                std::cout << "  (skipping empty buffer)" << std::endl;
+            }
             continue;
         }
 
@@ -293,7 +278,7 @@ int main(int narg, char *argv[]){
         std::vector<float> h_in(rows * in_cols, 0);
         memcpy(h_in.data(), recv_buffer.data(), curr_inBytes);
 
-        if (debug_mode) {
+        if (verbose_mode) {
             std::cout << "First 10 elements of h_in:" << std::endl;
             for (size_t i = 0; i < std::min(h_in.size(), static_cast<size_t>(10)); ++i) {
                 std::cout << h_in[i] << " ";
@@ -303,7 +288,9 @@ int main(int narg, char *argv[]){
 
         // Copy input matrix to GPU
         CUDA_CALL(cudaMalloc(&d_in, rows * in_cols * sizeof(float)));
-        std::cout << "\t Input matrix dimension, (#columns)x(#rows): " << in_cols << "x" << rows << std::endl;
+        if (verbose_mode) {
+            std::cout << "\t Input matrix dimension, (#columns)x(#rows): " << in_cols << "x" << rows << std::endl;
+        }
         CUDA_CALL(cudaMemcpy(d_in, h_in.data(), rows * in_cols * sizeof(float), cudaMemcpyHostToDevice));
 
         // Set the random matrix d_rand on the GPU. d_rand has @var options.width rows.
@@ -313,7 +300,9 @@ int main(int narg, char *argv[]){
 
         int threadsPerBlock = 256;
         int numBlocks = (rand_elements + threadsPerBlock - 1) / threadsPerBlock;
-        std::cout << "\t Random matrix dimension, (#columns)x(#rows): " << out_cols << "x" << options.width << std::endl;
+        if (verbose_mode) {
+            std::cout << "\t Random matrix dimension, (#columns)x(#rows): " << out_cols << "x" << options.width << std::endl;
+        }
         generateRandomMatrix<<<numBlocks, threadsPerBlock>>>(d_rand, options.width, out_cols, time(NULL));
         CUDA_CALL(cudaDeviceSynchronize());
 
@@ -327,15 +316,7 @@ int main(int narg, char *argv[]){
         std::vector<float> h_out(rows * out_cols, 0);
         CUDA_CALL(cudaMemcpy(h_out.data(), d_out, rows * out_cols * sizeof(float), cudaMemcpyDeviceToHost));
 
-        if (debug_mode) {
-            std::cout << "First 10 elements of h_out:" << std::endl;
-            for (size_t i = 0; i < std::min(h_out.size(), static_cast<size_t>(10)); ++i) {
-                std::cout << h_out[i] << " ";
-            }
-            std::cout << std::endl << std::endl;
-        }
-
-        if (options.test || debug_mode) {
+        if (verbose_mode) {
             std::vector<float> h_rand(rand_elements, 0);
             CUDA_CALL(cudaMemcpy(h_rand.data(), d_rand, rand_elements * sizeof(float), cudaMemcpyDeviceToHost));
     
@@ -355,11 +336,15 @@ int main(int narg, char *argv[]){
         }
 
         zmq::message_t message(h_out.data(), h_out.size() * sizeof(float));   // remember to * sizeof(float)!!!
-        std::cout <<"\t Output matrix dimension, (#columns)x(#rows): " << out_cols << "x" << rows << std::endl;
-        res = sender.send(message, zmq::send_flags::dontwait);   // has to be mq::send_flags::dontwait?
+        if (verbose_mode) {
+            std::cout <<"\t Output matrix dimension, (#columns)x(#rows): " << out_cols << "x" << rows << std::endl;
+        }
+
+        res = sender.send(message, zmq::send_flags::dontwait);   // zmq::send_flags::dontwait is non-blocking mode
         if (!res) {
             std::cerr << "Error: ZeroMQ send failed!" << std::endl;
-        } else {
+        }
+        if(verbose_mode) {
             std::cout << "Sent [" << res.value() << "] bytes via ZeroMQ socket.\n" << std::endl;
         }
 
@@ -367,35 +352,7 @@ int main(int narg, char *argv[]){
         CUDA_CALL(cudaFree(d_rand));
         CUDA_CALL(cudaFree(d_out));
 
-        // Print statistic
-        /// TODO: move to a monitoring thread instead.
-        auto now = std::chrono::high_resolution_clock::now();
-        // auto duration = std::chrono::duration<double>(now - last_time).count();
-        // auto rateMbps = curr_inBytes / duration * 8.0 / 1.0E6;
-        // auto savePrecision = std::cout.precision();
-        // std::cout << "  INCOMING data rate: " << std::fixed << std::setprecision(3)  << rateMbps << " (Mbps)" << std::endl;
-        // std::cout.precision(savePrecision);
-
-        // Log to SQLite DB
-        // auto utc_timestamp_in_ms =
-        //     std::chrono::duration_cast<std::chrono::milliseconds>(now.time_since_epoch()).count();
-        // std::string pid_str = std::to_string(getpid());
-        // std::ostringstream values;
-        // values << std::to_string(utc_timestamp_in_ms) << ", "
-        //     << pid_str << ", "
-        //     << std::fixed << std::setprecision(3)  // Ensure consistent floating-point precision
-        //     << rateHz << ", "
-        //     << rateMbps;
-        // if (!rate_logger.insertRateLog(RATE_DB_COLUMNS, values.str())) {
-        //     std::cerr << "Failed to insert record into the database." << std::endl;
-        // }
-
-        last_time = now;
-
-        // std::this_thread::sleep_for(std::chrono::seconds(1));
     }
-    // Close SQLite3 DB
-    // rate_logger.closeDB();
 
     return 0;
 }

--- a/rtdp/cuda/gpu_proxy/python_zmq_helper/zmq_fp_receiver.py
+++ b/rtdp/cuda/gpu_proxy/python_zmq_helper/zmq_fp_receiver.py
@@ -24,29 +24,62 @@ Date: 2025-03-10
 """
 
 import zmq
+import time
+import threading
 import numpy as np
 import argparse
 
+total_recv_bytes = 0
+stop_flag = False
+lock = threading.Lock()
+
+
+def rate_logger():
+    """The rate logger thread. Log the recv rate every 2 seconds."""
+    global total_recv_bytes, stop_flag
+    while not stop_flag:
+        pre_recv_bytes = total_recv_bytes
+        time.sleep(2)
+        with lock:
+            rate = (total_recv_bytes - pre_recv_bytes) / (2.0e6)
+            if rate == 0:
+                continue
+            print(f"curr_recv_rate = {rate} MB/s")
+
 def main():
+    global total_recv_bytes, stop_flag, lock
+
     parser = argparse.ArgumentParser(description="ZMQ Floating Point Data Receiver")
     parser.add_argument("-p", "--port", type=int, default=55556, help="Port number to receive data on (default: 55555)")
-    
+    parser.add_argument("-v", "--verbose", action="store_true", help="Print the first 10 floats for each msg")
+
     args = parser.parse_args()
     
     context = zmq.Context()
     socket = context.socket(zmq.PULL)
+    socket.setsockopt(zmq.RCVHWM, 1000)   # Set high water mark
     socket.bind(f"tcp://*:{args.port}")
 
     print(f"Receiving data on port {args.port}...")
+
+    # Start the rate logger thread
+    thread = threading.Thread(target=rate_logger)
+    thread.daemon = True
+    thread.start()
 
     try:
         while True:
             message = socket.recv()
             data = np.frombuffer(message, dtype=np.float32)
-            print(f"Received bytes: {len(message)}")
-            print(f"First 10 floats: {data[:10]}\n")
+            with lock:  # Python GIL lock
+                total_recv_bytes += len(message)
+            if args.verbose:
+                print(f"Received [{len(message)}] bytes")
+                print(f"\tFirst 10 floats: {data[:10]}\n")
     except KeyboardInterrupt:
         print("\nTerminating receiver.")
+        stop_flag = True
+        thread.join()
     finally:
         socket.close()
         context.term()

--- a/rtdp/cuda/gpu_proxy/python_zmq_helper/zmq_fp_sender.py
+++ b/rtdp/cuda/gpu_proxy/python_zmq_helper/zmq_fp_sender.py
@@ -30,7 +30,6 @@ import numpy as np
 
 
 DATA_NUMPY_WIDTH = 20480000  # Sending data grouped by this dimension. 40960000 does not work!
-BYTES_PER_MESSAGE = DATA_NUMPY_WIDTH * 4  # float32 = 4 bytes
 
 def main():
     parser = argparse.ArgumentParser(description="ZMQ Floating Point Data Sender")
@@ -40,13 +39,18 @@ def main():
                         "--port", type=int, default=55555, help="Port number to send data to (default: 55555)")
     parser.add_argument("-i",
                         "--all-ones", action="store_true", help="Send all ones if enabled (default: random values)")
-    parser.add_argument("--rate", type=float, default=500.0,
+    parser.add_argument(
+                        "--group-size", type=int, default=DATA_NUMPY_WIDTH,
+                        help=f"The number of float number each ZMQ msg contains (default: {DATA_NUMPY_WIDTH})")
+    parser.add_argument("-r",
+                        "--rate", type=float, default=500.0,
                         help="Average MB/s to send (default = 500)")
     
     args = parser.parse_args()
     
     context = zmq.Context()
     socket = context.socket(zmq.PUSH)
+    socket.setsockopt(zmq.SNDHWM, 1000)  # set send high-water mark to 1000 messages
     socket.connect(f"tcp://{args.ip_addr}:{args.port}")
     
     print(f"Sending data to {args.ip_addr}:{args.port} {'(all ones)' if args.all_ones else '(random values)'}")
@@ -55,10 +59,9 @@ def main():
         print(f"Target send rate: {args.rate} MB/s\n")
 
     # Calculate time interval between sends to maintain the desired MB/s rate
-    interval = 0
     if args.rate > 0:
-        interval = max(1.0, BYTES_PER_MESSAGE / (args.rate * 1e6))
-        print(f"Sent interval: {interval * 1000} ms")
+        interval = (args.group_size * 4.0) / (args.rate * 1e6)
+        print(f"Each message needs: {interval * 1000} ms")
     else:
         print(f"--rate should be a positive number!!!")
         exit(-1)
@@ -67,23 +70,24 @@ def main():
 
     try:
         while True:
+            start = time.time()
             if args.all_ones:
-                data = np.ones(DATA_NUMPY_WIDTH, dtype=np.float32)
+                data = np.ones(args.group_size, dtype=np.float32)
             else:
-                data = np.random.rand(DATA_NUMPY_WIDTH).astype(np.float32)
+                data = np.random.rand(args.group_size).astype(np.float32)
 
-            socket.send(data.tobytes())
+            socket.send(data.tobytes())  # blocks until all data is sent
+            duration = time.time() - start  # data is handled to ZMQ queue but not fully sent out
 
-            if interval > 0:
-                next_send_time += interval
-                now = time.perf_counter()
-                sleep_duration = next_send_time - now
-                if sleep_duration > 0:
-                    print(f"\tSent {data.nbytes / 1e6} MB, sleep for {sleep_duration * 1000} ms...")
-                    time.sleep(sleep_duration)  
-                else:
-                    # Falling behind: skip sleep to catch up
-                    next_send_time = now
+            remaining = 1.0 - duration
+            if remaining > 0:
+                print(f"\tSent {data.nbytes / 1e6} MB, ",
+                    f"scurr_send_rate={max(args.rate, data.nbytes / (duration * 1e6))} MB/s, duration={duration * 1000} ms")
+                print(f"\tSleep for {remaining * 1000} ms...\n")
+                time.sleep(remaining)
+            else:
+                print(f"\tSent {data.nbytes / 1e6} MB, curr_send_rate={data.nbytes / (duration * 1e6)} MB/s, duration={duration * 1000} ms")
+
     except KeyboardInterrupt:
         print("\nTerminating sender.")
     finally:

--- a/rtdp/cuda/gpu_proxy/python_zmq_helper/zmq_fp_sender.py
+++ b/rtdp/cuda/gpu_proxy/python_zmq_helper/zmq_fp_sender.py
@@ -82,7 +82,7 @@ def main():
             remaining = 1.0 - duration
             if remaining > 0:
                 print(f"\tSent {data.nbytes / 1e6} MB, ",
-                    f"scurr_send_rate={max(args.rate, data.nbytes / (duration * 1e6))} MB/s, duration={duration * 1000} ms")
+                    f"curr_send_rate={max(args.rate, data.nbytes / (duration * 1e6))} MB/s, duration={duration * 1000} ms")
                 print(f"\tSleep for {remaining * 1000} ms...\n")
                 time.sleep(remaining)
             else:


### PR DESCRIPTION
Address issue #73 

Notes:
- High watermark and non-blocking send is already in the `.cu` code.
- Using the IB addresses, I can get quite high numbers:
   - Python sender: `python python_zmq_helper/zmq_fp_sender.py -a 172.17.1.13 -r 5000 --group-size=500000000`, this will send at ~500 MB/s;
   - `gpu_emu`: `../bin/gpu_emu -a 172.17.1.54 -w 10240 -r 1.0`, adjust matrix column width (cannot be too large otherwise have memory issue) and out ratio, it can get as high as ~ 1 GB/s;
   - Python receiver: can report rates up to ~2 GB/s.
   
  The bottleneck looks like the Python sender.
---
Updates:
- [x] Python sender:
    - [x] Implement rate limiter;
    - [x] Add high water mark.
- [x] CMakeLists: add install part.
- [x] gpu_emu.cu
   - [x] Print the send/recv rate on the CPU side;
   - [x] `--verbose` mode.
- [x] Python receiver:
   - [x] A rate logger print every 2s
   - [x] High water mark
   - [x] verbose mode to print first 10 elements

