### PR TITLE
Farm-nic-test

### DIFF
--- a/src/utilities/scripts/farm-nic-test/Dockerfile
+++ b/src/utilities/scripts/farm-nic-test/Dockerfile
@@ -9,8 +9,12 @@ RUN apt-get update && apt-get install -y \
 COPY nic_test.py /usr/local/bin/nic_test.py
 RUN chmod +x /usr/local/bin/nic_test.py
 
+# Create a script to run the server
+COPY run_server.sh /usr/local/bin/run_server.sh
+RUN chmod +x /usr/local/bin/run_server.sh
+
 # Set the working directory
 WORKDIR /app
 
-# Set the entrypoint to our script
+# Default to running the client test
 ENTRYPOINT ["python3", "/usr/local/bin/nic_test.py"] 

--- a/src/utilities/scripts/farm-nic-test/Dockerfile
+++ b/src/utilities/scripts/farm-nic-test/Dockerfile
@@ -9,12 +9,8 @@ RUN apt-get update && apt-get install -y \
 COPY nic_test.py /usr/local/bin/nic_test.py
 RUN chmod +x /usr/local/bin/nic_test.py
 
-# Create a script to run the server
-COPY run_server.sh /usr/local/bin/run_server.sh
-RUN chmod +x /usr/local/bin/run_server.sh
-
 # Set the working directory
 WORKDIR /app
 
-# Default to running the client test
-ENTRYPOINT ["python3", "/usr/local/bin/nic_test.py"] 
+# Remove the default entrypoint to allow running either client or server
+# ENTRYPOINT ["python3", "/usr/local/bin/nic_test.py"] 

--- a/src/utilities/scripts/farm-nic-test/Dockerfile
+++ b/src/utilities/scripts/farm-nic-test/Dockerfile
@@ -1,0 +1,16 @@
+FROM python:3.9-slim
+
+# Install iperf2 and other dependencies
+RUN apt-get update && apt-get install -y \
+    iperf \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy the Python script
+COPY nic_test.py /usr/local/bin/nic_test.py
+RUN chmod +x /usr/local/bin/nic_test.py
+
+# Set the working directory
+WORKDIR /app
+
+# Set the entrypoint to our script
+ENTRYPOINT ["python3", "/usr/local/bin/nic_test.py"] 

--- a/src/utilities/scripts/farm-nic-test/README.md
+++ b/src/utilities/scripts/farm-nic-test/README.md
@@ -1,0 +1,122 @@
+# Farm NIC Test
+
+This tool helps test high-speed network interface card (NIC) performance using iperf2. It can be run using either Docker or Apptainer (formerly Singularity).
+
+## Prerequisites
+
+### For Docker:
+- Docker installed and running on both sender and receiver
+- Docker daemon has permissions to use host network
+
+### For Apptainer:
+- Apptainer installed on both sender and receiver
+- Root privileges (for building the SIF file)
+
+## Step-by-Step Instructions
+
+### 1. Receiver Side Setup
+
+First, on the receiver machine, start the iperf2 server:
+
+#### Using Docker:
+```bash
+# On receiver machine
+cd src/utilities/scripts/farm-nic-test
+./build.sh
+docker run -d --rm --network=host farm-nic-test iperf -s
+```
+
+#### Using Apptainer:
+```bash
+# On receiver machine
+cd src/utilities/scripts/farm-nic-test
+./build.sh
+./docker_to_apptainer.sh
+apptainer run rtdp-farm-nic-test.sif iperf -s
+```
+
+The server will run in the background and listen on port 5201. Keep this running while performing the test.
+
+### 2. Sender Side Setup and Test
+
+On the sender machine:
+
+#### Using Docker:
+
+1. Build the test image (if not already built):
+```bash
+cd src/utilities/scripts/farm-nic-test
+./build.sh
+```
+
+2. Run the test:
+```bash
+docker run --network=host farm-nic-test <receiver_ip>
+```
+
+Example:
+```bash
+docker run --network=host farm-nic-test 192.168.1.100
+```
+
+#### Using Apptainer:
+
+1. Build the Docker image (if not already built):
+```bash
+cd src/utilities/scripts/farm-nic-test
+./build.sh
+```
+
+2. Convert to Apptainer SIF (if not already done):
+```bash
+./docker_to_apptainer.sh
+```
+
+3. Run the test:
+```bash
+apptainer run rtdp-farm-nic-test.sif <receiver_ip>
+```
+
+Example:
+```bash
+apptainer run rtdp-farm-nic-test.sif 192.168.1.100
+```
+
+## Test Configuration
+
+- The test runs for 10 seconds to get a stable measurement
+- Uses iperf2 for network performance testing
+- Reports transmission rate in Gbits/sec
+- Uses host network mode for accurate NIC testing
+
+## Output
+
+The test will output the transmission rate in Gbits/sec. Example output:
+```
+Testing NIC speed with receiver IP: 192.168.1.100
+Transmission rate: 9.85 Gbits/sec
+```
+
+## Troubleshooting
+
+1. If you get permission errors with Docker:
+   - Ensure your user is in the docker group
+   - Try running with sudo (not recommended for production)
+
+2. If you get network errors:
+   - Ensure the receiver IP is correct and reachable
+   - Check if port 5201 is available and not blocked by firewall
+   - Verify network interface permissions
+   - Make sure the iperf2 server is running on the receiver side
+
+3. If Apptainer build fails:
+   - Ensure you have root privileges
+   - Check if Apptainer is properly installed
+   - Verify the Docker image exists and is accessible
+
+## Notes
+
+- The test requires both sender and receiver machines to be on the same network
+- For best results, ensure no other network-intensive applications are running
+- The test uses TCP for reliable transmission rate measurement
+- The receiver must have an iperf2 server running before starting the test 

--- a/src/utilities/scripts/farm-nic-test/README.md
+++ b/src/utilities/scripts/farm-nic-test/README.md
@@ -14,72 +14,43 @@ This tool helps test high-speed network interface card (NIC) performance using i
 
 ## Step-by-Step Instructions
 
-### 1. Receiver Side Setup
+### 1. Initial Setup (One-time setup)
 
-First, on the receiver machine, start the iperf2 server:
-
-#### Using Docker:
+First, build the Docker image and convert it to Apptainer SIF:
 ```bash
-# On receiver machine
-cd src/utilities/scripts/farm-nic-test
-./build.sh
-docker run -d --rm --network=host farm-nic-test iperf -s
-```
-
-#### Using Apptainer:
-```bash
-# On receiver machine
 cd src/utilities/scripts/farm-nic-test
 ./build.sh
 ./docker_to_apptainer.sh
+```
+
+### 2. Running the Test
+
+#### Using Convenience Scripts (Recommended)
+
+1. On the receiver machine:
+```bash
+./run_receiver.sh
+```
+
+2. On the sender machine:
+```bash
+./run_sender.sh <receiver_ip>
+```
+Example:
+```bash
+./run_sender.sh 192.168.1.100
+```
+
+#### Manual Commands
+
+##### Receiver Side:
+```bash
 apptainer run rtdp-farm-nic-test.sif iperf -s
 ```
 
-The server will run in the background and listen on port 5201. Keep this running while performing the test.
-
-### 2. Sender Side Setup and Test
-
-On the sender machine:
-
-#### Using Docker:
-
-1. Build the test image (if not already built):
+##### Sender Side:
 ```bash
-cd src/utilities/scripts/farm-nic-test
-./build.sh
-```
-
-2. Run the test:
-```bash
-docker run --network=host farm-nic-test <receiver_ip>
-```
-
-Example:
-```bash
-docker run --network=host farm-nic-test 192.168.1.100
-```
-
-#### Using Apptainer:
-
-1. Build the Docker image (if not already built):
-```bash
-cd src/utilities/scripts/farm-nic-test
-./build.sh
-```
-
-2. Convert to Apptainer SIF (if not already done):
-```bash
-./docker_to_apptainer.sh
-```
-
-3. Run the test:
-```bash
-apptainer run rtdp-farm-nic-test.sif <receiver_ip>
-```
-
-Example:
-```bash
-apptainer run rtdp-farm-nic-test.sif 192.168.1.100
+apptainer run rtdp-farm-nic-test.sif /usr/local/bin/nic_test.py <receiver_ip>
 ```
 
 ## Test Configuration

--- a/src/utilities/scripts/farm-nic-test/build.sh
+++ b/src/utilities/scripts/farm-nic-test/build.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Build the Docker image
+docker build -t jlabtsai/rtdp-farm-nic-test .
+
+# Push the Docker image to Docker Hub
+docker push jlabtsai/rtdp-farm-nic-test
+
+# Run the test
+echo "Usage: docker run --network=host jlabtsai/rtdp-farm-nic-test <receiver_ip>"
+echo "Example: docker run --network=host jlabtsai/rtdp-farm-nic-test 192.168.1.100" 

--- a/src/utilities/scripts/farm-nic-test/docker_to_apptainer.sh
+++ b/src/utilities/scripts/farm-nic-test/docker_to_apptainer.sh
@@ -12,7 +12,7 @@ echo "Using temporary directory: $TMP_DIR"
 
 # Convert Docker image to Apptainer SIF
 echo "Converting Docker image to Apptainer SIF..."
-apptainer build $TMP_DIR/rtdp-farm-nic-test.sif docker://jlabtsai/rtdp-farm-nic-test
+apptainer build $TMP_DIR/rtdp-farm-nic-test.sif docker-daemon://farm-nic-test:latest
 
 # Move the SIF file to the current directory
 mv $TMP_DIR/rtdp-farm-nic-test.sif .
@@ -23,5 +23,14 @@ rm -rf $TMP_DIR
 echo "Conversion complete!"
 echo "Apptainer SIF file created: rtdp-farm-nic-test.sif"
 echo ""
-echo "Usage: apptainer run --network-args \"portmap=5201:5201/tcp\" rtdp-farm-nic-test.sif <receiver_ip>"
-echo "Example: apptainer run --network-args \"portmap=5201:5201/tcp\" rtdp-farm-nic-test.sif 192.168.1.100" 
+echo "=== Instructions for both sender and receiver ==="
+echo ""
+echo "1. Receiver Side (Run this first):"
+echo "   apptainer run rtdp-farm-nic-test.sif iperf -s"
+echo ""
+echo "2. Sender Side (Run after receiver is ready):"
+echo "   apptainer run rtdp-farm-nic-test.sif /usr/local/bin/nic_test.py <receiver_ip>"
+echo "   Example: apptainer run rtdp-farm-nic-test.sif /usr/local/bin/nic_test.py 192.168.1.100"
+echo ""
+echo "Note: Make sure to run the receiver side first and keep it running"
+echo "      while performing the test from the sender side." 

--- a/src/utilities/scripts/farm-nic-test/docker_to_apptainer.sh
+++ b/src/utilities/scripts/farm-nic-test/docker_to_apptainer.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# Check if apptainer is installed
+if ! command -v apptainer &> /dev/null; then
+    echo "Error: apptainer is not installed. Please install apptainer first."
+    exit 1
+fi
+
+# Check if Docker image exists
+if ! docker image inspect jlabtsai/rtdp-farm-nic-test &> /dev/null; then
+    echo "Error: Docker image jlabtsai/rtdp-farm-nic-test not found."
+    echo "Please build the Docker image first using build.sh"
+    exit 1
+fi
+
+# Create a temporary directory for the build
+TMP_DIR=$(mktemp -d)
+echo "Using temporary directory: $TMP_DIR"
+
+# Convert Docker image to Apptainer SIF
+echo "Converting Docker image to Apptainer SIF..."
+apptainer build $TMP_DIR/rtdp-farm-nic-test.sif docker://jlabtsai/rtdp-farm-nic-test
+
+# Move the SIF file to the current directory
+mv $TMP_DIR/rtdp-farm-nic-test.sif .
+
+# Clean up
+rm -rf $TMP_DIR
+
+echo "Conversion complete!"
+echo "Apptainer SIF file created: rtdp-farm-nic-test.sif"
+echo ""
+echo "Usage: apptainer run --network-args \"portmap=5201:5201/tcp\" rtdp-farm-nic-test.sif <receiver_ip>"
+echo "Example: apptainer run --network-args \"portmap=5201:5201/tcp\" rtdp-farm-nic-test.sif 192.168.1.100" 

--- a/src/utilities/scripts/farm-nic-test/docker_to_apptainer.sh
+++ b/src/utilities/scripts/farm-nic-test/docker_to_apptainer.sh
@@ -6,13 +6,6 @@ if ! command -v apptainer &> /dev/null; then
     exit 1
 fi
 
-# Check if Docker image exists
-if ! docker image inspect jlabtsai/rtdp-farm-nic-test &> /dev/null; then
-    echo "Error: Docker image jlabtsai/rtdp-farm-nic-test not found."
-    echo "Please build the Docker image first using build.sh"
-    exit 1
-fi
-
 # Create a temporary directory for the build
 TMP_DIR=$(mktemp -d)
 echo "Using temporary directory: $TMP_DIR"

--- a/src/utilities/scripts/farm-nic-test/docker_to_apptainer.sh
+++ b/src/utilities/scripts/farm-nic-test/docker_to_apptainer.sh
@@ -6,19 +6,9 @@ if ! command -v apptainer &> /dev/null; then
     exit 1
 fi
 
-# Create a temporary directory for the build
-TMP_DIR=$(mktemp -d)
-echo "Using temporary directory: $TMP_DIR"
-
 # Convert Docker image to Apptainer SIF
 echo "Converting Docker image to Apptainer SIF..."
-apptainer build $TMP_DIR/rtdp-farm-nic-test.sif docker-daemon://farm-nic-test:latest
-
-# Move the SIF file to the current directory
-mv $TMP_DIR/rtdp-farm-nic-test.sif .
-
-# Clean up
-rm -rf $TMP_DIR
+apptainer build rtdp-farm-nic-test.sif docker://jlabtsai/rtdp-farm-nic-test
 
 echo "Conversion complete!"
 echo "Apptainer SIF file created: rtdp-farm-nic-test.sif"
@@ -26,11 +16,11 @@ echo ""
 echo "=== Instructions for both sender and receiver ==="
 echo ""
 echo "1. Receiver Side (Run this first):"
-echo "   apptainer run rtdp-farm-nic-test.sif iperf -s"
+echo "   ./run_receiver.sh"
 echo ""
 echo "2. Sender Side (Run after receiver is ready):"
-echo "   apptainer run rtdp-farm-nic-test.sif /usr/local/bin/nic_test.py <receiver_ip>"
-echo "   Example: apptainer run rtdp-farm-nic-test.sif /usr/local/bin/nic_test.py 192.168.1.100"
+echo "   ./run_sender.sh <receiver_ip>"
+echo "   Example: ./run_sender.sh 192.168.1.100"
 echo ""
 echo "Note: Make sure to run the receiver side first and keep it running"
 echo "      while performing the test from the sender side." 

--- a/src/utilities/scripts/farm-nic-test/nic_test.py
+++ b/src/utilities/scripts/farm-nic-test/nic_test.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+
+import subprocess
+import sys
+import argparse
+import re
+
+def run_iperf_test(receiver_ip):
+    """
+    Run iperf2 test using Docker containers for both sender and receiver.
+    Returns the transmission rate in Gbits/sec.
+    """
+    try:
+        # Start iperf server (receiver) in Docker
+        server_cmd = [
+            "docker", "run", "-d", "--rm",
+            "--network=host",
+            "networkstatic/iperf2",
+            "iperf", "-s"
+        ]
+        server_container = subprocess.run(server_cmd, capture_output=True, text=True)
+        server_id = server_container.stdout.strip()
+
+        # Run iperf client (sender) in Docker
+        client_cmd = [
+            "docker", "run", "--rm",
+            "--network=host",
+            "networkstatic/iperf2",
+            "iperf", "-c", receiver_ip, "-t", "10"
+        ]
+        result = subprocess.run(client_cmd, capture_output=True, text=True)
+
+        # Clean up server container
+        subprocess.run(["docker", "stop", server_id])
+
+        # Parse the output to get the transmission rate
+        match = re.search(r'(\d+\.\d+)\s*Gbits/sec', result.stdout)
+        if match:
+            return float(match.group(1))
+        else:
+            print("Error: Could not parse iperf output")
+            return None
+
+    except Exception as e:
+        print(f"Error running iperf test: {str(e)}")
+        return None
+
+def main():
+    parser = argparse.ArgumentParser(description='Test NIC speed using iperf2')
+    parser.add_argument('receiver_ip', help='IP address of the receiver NIC')
+    args = parser.parse_args()
+
+    print(f"Testing NIC speed with receiver IP: {args.receiver_ip}")
+    rate = run_iperf_test(args.receiver_ip)
+    
+    if rate is not None:
+        print(f"Transmission rate: {rate} Gbits/sec")
+    else:
+        print("Failed to measure transmission rate")
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main() 

--- a/src/utilities/scripts/farm-nic-test/run_receiver.sh
+++ b/src/utilities/scripts/farm-nic-test/run_receiver.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Check if apptainer is installed
+if ! command -v apptainer &> /dev/null; then
+    echo "Error: apptainer is not installed. Please install apptainer first."
+    exit 1
+fi
+
+# Check if SIF file exists
+if [ ! -f "rtdp-farm-nic-test.sif" ]; then
+    echo "Error: rtdp-farm-nic-test.sif not found. Please run ./docker_to_apptainer.sh first."
+    exit 1
+fi
+
+echo "Starting iperf2 server..."
+echo "Press Ctrl+C to stop the server"
+echo ""
+
+# Run the server
+apptainer run rtdp-farm-nic-test.sif iperf -s 

--- a/src/utilities/scripts/farm-nic-test/run_receiver.sh
+++ b/src/utilities/scripts/farm-nic-test/run_receiver.sh
@@ -12,9 +12,9 @@ if [ ! -f "rtdp-farm-nic-test.sif" ]; then
     exit 1
 fi
 
-echo "Starting iperf2 server..."
+echo "Starting iperf2 server on port 52011..."
 echo "Press Ctrl+C to stop the server"
 echo ""
 
-# Run the server
-apptainer run rtdp-farm-nic-test.sif iperf -s 
+# Run the server with high-number port
+apptainer run rtdp-farm-nic-test.sif iperf -s -p 52011 

--- a/src/utilities/scripts/farm-nic-test/run_sender.sh
+++ b/src/utilities/scripts/farm-nic-test/run_sender.sh
@@ -20,8 +20,8 @@ if [ -z "$1" ]; then
     exit 1
 fi
 
-echo "Running NIC test with receiver IP: $1"
+echo "Running NIC test with receiver IP: $1 on port 52011"
 echo ""
 
-# Run the test
-apptainer run rtdp-farm-nic-test.sif /usr/local/bin/nic_test.py "$1" 
+# Run the test with high-number port
+apptainer run rtdp-farm-nic-test.sif /usr/local/bin/nic_test.py "$1" 52011 

--- a/src/utilities/scripts/farm-nic-test/run_sender.sh
+++ b/src/utilities/scripts/farm-nic-test/run_sender.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# Check if apptainer is installed
+if ! command -v apptainer &> /dev/null; then
+    echo "Error: apptainer is not installed. Please install apptainer first."
+    exit 1
+fi
+
+# Check if SIF file exists
+if [ ! -f "rtdp-farm-nic-test.sif" ]; then
+    echo "Error: rtdp-farm-nic-test.sif not found. Please run ./docker_to_apptainer.sh first."
+    exit 1
+fi
+
+# Check if receiver IP is provided
+if [ -z "$1" ]; then
+    echo "Error: Please provide the receiver's IP address"
+    echo "Usage: ./run_sender.sh <receiver_ip>"
+    echo "Example: ./run_sender.sh 192.168.1.100"
+    exit 1
+fi
+
+echo "Running NIC test with receiver IP: $1"
+echo ""
+
+# Run the test
+apptainer run rtdp-farm-nic-test.sif /usr/local/bin/nic_test.py "$1" 

--- a/src/utilities/scripts/farm-nic-test/run_server.sh
+++ b/src/utilities/scripts/farm-nic-test/run_server.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# Run iperf2 server
+iperf -s 

--- a/src/utilities/scripts/farm-nic-test/run_server.sh
+++ b/src/utilities/scripts/farm-nic-test/run_server.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-# Run iperf2 server
-iperf -s 


### PR DESCRIPTION
- Updated nic_test.py to accept a port parameter for the iperf test, defaulting to 52011.
- Enhanced output parsing to handle different transmission rate formats (Gbits, Mbits, Kbits).
- Modified run_receiver.sh and run_sender.sh to reflect the new port usage in their echo statements and commands.