### PR TITLE
Davidl gpu dockerfile

### DIFF
--- a/rtdp/cuda/gpu_proxy/Dockerfile
+++ b/rtdp/cuda/gpu_proxy/Dockerfile
@@ -1,17 +1,17 @@
 #
 # To build the image on ifarm do this:
 #--------------------------------------------------------------------------------
-# podman build -t rtdp-gpu_proxy -f Dockerfile .
+# docker build -t rtdp-gpu_proxy -f Dockerfile .
 #
 #
 # To push to the JLab container image registry:
 #--------------------------------------------------------------------------------
-# podman tag rtdp-gpu_proxy code.jlab.org/epsci/rtdp-gpu_proxy
-# podman login code.jlab.org
-# podman push code.jlab.org/epsci/rtdp-gpu_proxy
+# docker tag rtdp-gpu_proxy code.jlab.org/epsci/rtdp-gpu_proxy
+# docker login code.jlab.org
+# docker push code.jlab.org/epsci/rtdp-gpu_proxy
 # 
 
-FROM docker://nvidia/cuda:12.6.0-devel-ubuntu22.04 AS builder
+FROM docker.io/nvidia/cuda:12.6.0-devel-ubuntu22.04 AS builder
 
 LABEL maintainer="Jeng-Yuan Tsai"
 LABEL version="1.0.1"
@@ -45,7 +45,7 @@ RUN cmake -S . -B build -DCMAKE_INSTALL_PREFIX=/app && \
     cmake --build build --target install -j$(nproc)
 
 # Runtime stage
-FROM docker://nvidia/cuda:12.6.0-runtime-ubuntu22.04 AS runtime
+FROM docker.io/nvidia/cuda:12.6.0-runtime-ubuntu22.04 AS runtime
 
 # Copy the application files
 COPY --from=builder /app/ /app/

--- a/rtdp/cuda/gpu_proxy/Dockerfile
+++ b/rtdp/cuda/gpu_proxy/Dockerfile
@@ -1,7 +1,20 @@
-FROM nvidia/cuda:12.6.0-devel-ubuntu22.04
+#
+# To build the image on ifarm do this:
+#--------------------------------------------------------------------------------
+# podman build -t rtdp-gpu_proxy -f Dockerfile .
+#
+#
+# To push to the JLab container image registry:
+#--------------------------------------------------------------------------------
+# podman tag rtdp-gpu_proxy:latest codecr.jlab.org/epsci/rtdp-gpu_proxy:latest
+# podman login codecr.jlab.org
+# podman push codecr.jlab.org/epsci/rtdp-gpu_proxy:latest
+# 
+
+FROM docker://nvidia/cuda:12.6.0-devel-ubuntu22.04 AS builder
 
 LABEL maintainer="Jeng-Yuan Tsai"
-LABEL version="1.0.0"
+LABEL version="1.0.1"
 
 # Set environment variables
 ENV PATH=/usr/local/cuda/bin:$PATH
@@ -20,19 +33,27 @@ RUN apt-get update && apt-get install -y \
     git \
     && rm -rf /var/lib/apt/lists/*
 
-# Install Python dependencies
-RUN pip3 install pyzmq numpy
-
 # Create and set working directory
-WORKDIR /app
+WORKDIR /work
 
 # Copy the application files
-COPY . /app/
+COPY CMakeLists.txt gpuEmu.cu python_zmq_helper /work/
+COPY python_zmq_helper /work/python_zmq_helper/
 
 # Build the application
-RUN mkdir -p build && cd build && \
-    cmake .. && \
-    make -j$(nproc)
+RUN cmake -S . -B build -DCMAKE_INSTALL_PREFIX=/app && \
+    cmake --build build --target install -j$(nproc)
+
+# Runtime stage
+FROM docker://nvidia/cuda:12.6.0-runtime-ubuntu22.04 AS runtime
+
+# Copy the application files
+COPY --from=builder /app/ /app/
+
+# Install Python dependencies
+RUN apt-get update && apt-get install -y python3-pip libzmq5 \
+    && pip3 install pyzmq numpy \
+    && rm -rf /var/lib/apt/lists/*
 
 # Create a simple entrypoint script
 RUN echo '#!/bin/bash\n\
@@ -81,17 +102,17 @@ case $mode in\n\
             echo "Error: No arguments provided for proxy mode. Use -h for help."\n\
             exit 1\n\
         fi\n\
-        exec /app/build/gpu_emu "$@"\n\
+        exec /app/bin/gpu_emu "$@"\n\
         ;;\n\
     sender)\n\
         if [ $# -eq 0 ]; then\n\
             echo "Error: No arguments provided for sender mode. Use -h for help."\n\
             exit 1\n\
         fi\n\
-        exec python3 /app/python_zmq_helper/zmq_fp_sender.py "$@"\n\
+        exec python3 /app/bin/zmq_fp_sender.py "$@"\n\
         ;;\n\
     receiver)\n\
-        exec python3 /app/python_zmq_helper/zmq_fp_receiver.py "$@"\n\
+        exec python3 /app/bin/zmq_fp_receiver.py "$@"\n\
         ;;\n\
     *)\n\
         echo "Error: Unknown mode $mode. Use --help for available modes."\n\

--- a/rtdp/cuda/gpu_proxy/Dockerfile
+++ b/rtdp/cuda/gpu_proxy/Dockerfile
@@ -6,9 +6,9 @@
 #
 # To push to the JLab container image registry:
 #--------------------------------------------------------------------------------
-# podman tag rtdp-gpu_proxy:latest codecr.jlab.org/epsci/rtdp-gpu_proxy:latest
-# podman login codecr.jlab.org
-# podman push codecr.jlab.org/epsci/rtdp-gpu_proxy:latest
+# podman tag rtdp-gpu_proxy code.jlab.org/epsci/rtdp-gpu_proxy
+# podman login code.jlab.org
+# podman push code.jlab.org/epsci/rtdp-gpu_proxy
 # 
 
 FROM docker://nvidia/cuda:12.6.0-devel-ubuntu22.04 AS builder
@@ -98,17 +98,9 @@ shift\n\
 \n\
 case $mode in\n\
     proxy)\n\
-        if [ $# -eq 0 ]; then\n\
-            echo "Error: No arguments provided for proxy mode. Use -h for help."\n\
-            exit 1\n\
-        fi\n\
         exec /app/bin/gpu_emu "$@"\n\
         ;;\n\
     sender)\n\
-        if [ $# -eq 0 ]; then\n\
-            echo "Error: No arguments provided for sender mode. Use -h for help."\n\
-            exit 1\n\
-        fi\n\
         exec python3 /app/bin/zmq_fp_sender.py "$@"\n\
         ;;\n\
     receiver)\n\


### PR DESCRIPTION
This makes the following changes to the Dockerfile used to build the rtdp-gpu_proxy image

1. Uses seperate `builder` and `runtime` images to reduce the image from ~7.5GB to ~2.7GB
2. Prefixes base images with `docker.io/` to allow building image with either podman or docker
3. Remove check on arguments when running "proxy" or "sender" since neither technically need them. 